### PR TITLE
Create apple-app-site-association for FlickType

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -2,7 +2,7 @@
   "applinks": {
       "details": [
            {
-             "appIDs": [ "12345ABCDE.com.nicegram.Telegram-iOS.watchkitapp.watchkitextension" ],
+             "appIDs": [ "ZUU76P392K.com.nicegram.Telegram-iOS.watchkitapp.watchkitextension" ],
              "components": [ { "/": "/flicktype/*" } ]
            }
        ]

--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,10 @@
+{
+  "applinks": {
+      "details": [
+           {
+             "appIDs": [ "12345ABCDE.com.nicegram.Telegram-iOS.watchkitapp.watchkitextension" ],
+             "components": [ { "/": "/flicktype/*" } ]
+           }
+       ]
+   }
+}


### PR DESCRIPTION
NOTE: This is currently using a placeholder team ID. 

Please replace the placeholder ID with your actual team ID, and ensure the bundle ID is the ID of your watch extension target as described in the [FlickTypeKit docs](https://github.com/FlickType/FlickTypeKit/tree/objc).

Relates to https://github.com/nicegram/Telegram-iOS/pull/110